### PR TITLE
Use standard Linux framebuffer ioctls to determine width and height, and scale touch appropriately

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,11 +1,82 @@
+//! Linux framebuffer interface for Kindle e-ink displays.
+//!
+//! Opens `/dev/fb0`, queries the kernel for the actual screen geometry (so we
+//! work on any Kindle model), mmaps the pixel buffer, and issues EPDC refresh
+//! ioctls to push changes to the e-ink panel.
+
 use std::ops::Range;
 use std::os::fd::AsRawFd;
 
-pub(crate) const DISPLAY_WIDTH: u32 = 1072;
-pub(crate) const DISPLAY_HEIGHT: u32 = 1448;
-// Each row is 1088 bytes wide in memory even though only 1072 pixels show — the rest is padding.
-const FB_STRIDE: usize = 1088;
+// Standard Linux framebuffer ioctl numbers (see <linux/fb.h>).
+const FBIOGET_VSCREENINFO: libc::Ioctl = 0x4600;
+const FBIOGET_FSCREENINFO: libc::Ioctl = 0x4602;
 
+// These structs mirror the kernel's `fb_var_screeninfo` and `fb_fix_screeninfo`.
+// We only read from them - the fields we care about are `xres`, `yres` (visible
+// resolution) and `line_length` (stride in bytes per row, which may be larger
+// than xres due to alignment padding).
+
+#[repr(C)]
+#[derive(Default)]
+struct FbBitfield {
+    offset: u32,
+    length: u32,
+    msb_right: u32,
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct FbVarScreeninfo {
+    xres: u32,
+    yres: u32,
+    xres_virtual: u32,
+    yres_virtual: u32,
+    xoffset: u32,
+    yoffset: u32,
+    bits_per_pixel: u32,
+    grayscale: u32,
+    red: FbBitfield,
+    green: FbBitfield,
+    blue: FbBitfield,
+    transp: FbBitfield,
+    nonstd: u32,
+    activate: u32,
+    height: u32,
+    width: u32,
+    accel_flags: u32,
+    pixclock: u32,
+    left_margin: u32,
+    right_margin: u32,
+    upper_margin: u32,
+    lower_margin: u32,
+    hsync_len: u32,
+    vsync_len: u32,
+    sync: u32,
+    vmode: u32,
+    rotate: u32,
+    colorspace: u32,
+    reserved: [u32; 4],
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct FbFixScreeninfo {
+    id: [u8; 16],
+    smem_start: libc::c_ulong,
+    smem_len: u32,
+    type_: u32,
+    type_aux: u32,
+    visual: u32,
+    xpanstep: u16,
+    ypanstep: u16,
+    ywrapstep: u16,
+    line_length: u32,
+    mmio_start: libc::c_ulong,
+    mmio_len: u32,
+    accel: u32,
+    capabilities: u16,
+    reserved: [u16; 2],
+}
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -39,32 +110,82 @@ struct UpdateRequest {
     alternate_buffer: AlternateBuffer,
 }
 
-// Magic number the Kindle's display driver uses to mean "redraw this part of the screen".
-const MXCFB_SEND_UPDATE: libc::c_ulong = 0x4048_462e;
+// Kindle EPDC (Electrophoretic Display Controller) ioctl and constants.
+// The ioctl number was confirmed by stracing `eips` on a real device.
+const MXCFB_SEND_UPDATE: libc::Ioctl = 0x4048_462e;
 
-const WAVEFORM_MODE_GC16: u32 = 2;
-const WAVEFORM_MODE_AUTO: u32 = 257;
-const UPDATE_MODE_PARTIAL: u32 = 0;
-const UPDATE_MODE_FULL: u32 = 1;
-const TEMP_USE_AMBIENT: i32 = 0x1000;
+const WAVEFORM_MODE_GC16: u32 = 2; // Full 16-level grayscale refresh (slow, high quality)
+const WAVEFORM_MODE_AUTO: u32 = 257; // Let the driver pick the best waveform
+const UPDATE_MODE_PARTIAL: u32 = 0; // Only redraw the dirty region
+const UPDATE_MODE_FULL: u32 = 1; // Flash the whole screen (clears ghosting)
+const TEMP_USE_AMBIENT: i32 = 0x1000; // Use the panel's ambient temperature sensor
 
-
+/// Memory-mapped handle to the Kindle's e-ink framebuffer.
+///
+/// Pixel format is 8-bit grayscale (one byte per pixel). The `stride` may be
+/// wider than `width` due to hardware alignment requirements.
 pub(crate) struct Framebuffer {
     file: std::fs::File,
     map: *mut u8,
     len: usize,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    /// Bytes per row in the mmap (≥ width due to padding).
+    stride: usize,
 }
 
+// SAFETY: The mmap is process-wide and we only access it from the event loop thread.
 unsafe impl Send for Framebuffer {}
 
 impl Framebuffer {
+    /// Open the framebuffer device and query its geometry from the kernel.
+    ///
+    /// This works on any Kindle model - the resolution and stride are read at
+    /// runtime rather than being hardcoded.
     pub(crate) fn open() -> std::io::Result<Self> {
         let file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
             .open("/dev/fb0")?;
 
-        let len = FB_STRIDE * DISPLAY_HEIGHT as usize;
+        let fd = file.as_raw_fd();
+
+        let mut vinfo = FbVarScreeninfo::default();
+        if unsafe {
+            libc::ioctl(
+                fd,
+                FBIOGET_VSCREENINFO,
+                &mut vinfo as *mut _ as *mut libc::c_void,
+            )
+        } == -1
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let mut finfo = FbFixScreeninfo::default();
+        if unsafe {
+            libc::ioctl(
+                fd,
+                FBIOGET_FSCREENINFO,
+                &mut finfo as *mut _ as *mut libc::c_void,
+            )
+        } == -1
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let width = vinfo.xres;
+        let height = vinfo.yres;
+        let stride = finfo.line_length as usize;
+
+        if width == 0 || height == 0 || stride < width as usize {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid framebuffer geometry: {width}x{height}, stride={stride}"),
+            ));
+        }
+
+        let len = stride * height as usize;
 
         let map = unsafe {
             libc::mmap(
@@ -72,7 +193,7 @@ impl Framebuffer {
                 len,
                 libc::PROT_READ | libc::PROT_WRITE,
                 libc::MAP_SHARED,
-                file.as_raw_fd(),
+                fd,
                 0,
             )
         };
@@ -81,24 +202,38 @@ impl Framebuffer {
             return Err(std::io::Error::last_os_error());
         }
 
-        Ok(Self { file, map: map as *mut u8, len })
+        Ok(Self {
+            file,
+            map: map as *mut u8,
+            len,
+            width,
+            height,
+            stride,
+        })
     }
 
+    /// Write a horizontal span of grayscale pixels into the mmap at row `y`.
     pub(crate) fn write_line(&mut self, y: usize, x_range: Range<usize>, pixels: &[u8]) {
         let dst = unsafe {
             std::slice::from_raw_parts_mut(
-                self.map.add(y * FB_STRIDE + x_range.start),
+                self.map.add(y * self.stride + x_range.start),
                 pixels.len(),
             )
         };
         dst.copy_from_slice(pixels);
     }
 
+    /// Fill the entire visible area with a single grayscale value (0x00 = black, 0xff = white).
     pub(crate) fn fill(&mut self, value: u8) {
-        let dst = unsafe { std::slice::from_raw_parts_mut(self.map, self.len) };
-        dst.fill(value);
+        for y in 0..self.height as usize {
+            let dst = unsafe {
+                std::slice::from_raw_parts_mut(self.map.add(y * self.stride), self.width as usize)
+            };
+            dst.fill(value);
+        }
     }
 
+    /// Ask the EPDC to refresh a region of the e-ink panel.
     fn send_update(&self, region: UpdateRect, waveform: u32, mode: u32) {
         let update = UpdateRequest {
             update_region: region,
@@ -113,27 +248,39 @@ impl Framebuffer {
                 physical_address: 0,
                 width: 0,
                 height: 0,
-                update_region: UpdateRect { top: 0, left: 0, width: 0, height: 0 },
+                update_region: UpdateRect {
+                    top: 0,
+                    left: 0,
+                    width: 0,
+                    height: 0,
+                },
             },
         };
 
         unsafe {
             libc::ioctl(
                 self.file.as_raw_fd(),
-                MXCFB_SEND_UPDATE as _,
+                MXCFB_SEND_UPDATE,
                 &update as *const _,
             );
         }
     }
 
+    /// Full-screen GC16 refresh - flashes the display to clear ghosting.
     pub(crate) fn refresh_full(&self) {
         self.send_update(
-            UpdateRect { top: 0, left: 0, width: DISPLAY_WIDTH, height: DISPLAY_HEIGHT },
+            UpdateRect {
+                top: 0,
+                left: 0,
+                width: self.width,
+                height: self.height,
+            },
             WAVEFORM_MODE_GC16,
             UPDATE_MODE_FULL,
         );
     }
 
+    /// Partial refresh of a dirty rectangle - fast, but may leave faint ghosting.
     pub(crate) fn refresh_region(
         &self,
         origin: slint::PhysicalPosition,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2,15 +2,14 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+use slint::Rgb8Pixel;
 use slint::platform::software_renderer::{
     LineBufferProvider, MinimalSoftwareWindow, RepaintBufferType,
 };
 use slint::platform::{Platform, PlatformError, WindowAdapter};
-use slint::Rgb8Pixel;
 
-use crate::framebuffer::{Framebuffer, DISPLAY_HEIGHT, DISPLAY_WIDTH};
+use crate::framebuffer::Framebuffer;
 use crate::touch::TouchInput;
-
 
 struct KindleLineBuffer<'a> {
     fb: &'a mut Framebuffer,
@@ -49,8 +48,11 @@ pub(crate) struct KindlePlatform {
 impl KindlePlatform {
     pub(crate) fn new() -> Self {
         let window = MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
-        window.set_size(slint::PhysicalSize::new(DISPLAY_WIDTH, DISPLAY_HEIGHT));
-        Self { window, start: Instant::now() }
+        // Window size is set later once we know the actual display dimensions.
+        Self {
+            window,
+            start: Instant::now(),
+        }
     }
 }
 
@@ -67,14 +69,17 @@ impl Platform for KindlePlatform {
         let mut fb = Framebuffer::open()
             .map_err(|e| PlatformError::Other(format!("failed to open /dev/fb0: {e}")))?;
 
+        self.window
+            .set_size(slint::PhysicalSize::new(fb.width, fb.height));
+
         let mut touch = TouchInput::open()
             .map_err(|e| PlatformError::Other(format!("failed to open touch input: {e}")))?;
 
         fb.fill(0xff);
         fb.refresh_full();
 
-        let mut rgb_scratch = vec![Rgb8Pixel::default(); DISPLAY_WIDTH as usize];
-        let mut gray_scratch = vec![0u8; DISPLAY_WIDTH as usize];
+        let mut rgb_scratch = vec![Rgb8Pixel::default(); fb.width as usize];
+        let mut gray_scratch = vec![0u8; fb.width as usize];
 
         loop {
             touch.poll(&self.window);


### PR DESCRIPTION
Haven't yet tested this on my test Kindle but the ioctl calls are the same as the `eips` use. This is probably the most useful bit of the library I had written locally.