### PR TITLE
Add ioctl number for more modern Kindles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The resulting binary is statically linked against musl and runs directly on the 
 So far, the backend has been tested to work on:
 * Kindle Paperwhite 7th gen.
 * Kindle Touch 4th gen
+* Kindle Paperwhite 10th gen
  
 
 ## Roadmap

--- a/src/framebuffer/ffi.rs
+++ b/src/framebuffer/ffi.rs
@@ -109,6 +109,9 @@ pub(super) struct UpdateRequest {
 // The ioctl number was confirmed by stracing `eips` on a real device.
 pub(super) const MXCFB_SEND_UPDATE: libc::c_ulong = 0x4048_462e;
 
+// ioctl number for Kindle Paperwhite 10th gen, from strace.
+pub(super) const MXCFB_SEND_UPDATE_V2: libc::c_ulong = 0x4050_462e;
+
 // Blocks until the EPDC has finished applying the update with a given marker.
 pub(super) const MXCFB_WAIT_FOR_UPDATE_COMPLETE: libc::c_ulong = 0xc008_462f;
 

--- a/src/framebuffer/ffi.rs
+++ b/src/framebuffer/ffi.rs
@@ -105,6 +105,21 @@ pub(super) struct UpdateRequest {
     pub(super) alternate_buffer: AlternateBuffer,
 }
 
+#[repr(C)]
+pub(super) struct UpdateRequestRex {
+    pub(super) update_region: UpdateRect,
+    pub(super) waveform_mode: u32,
+    pub(super) update_mode: u32,
+    pub(super) update_marker: u32,
+    pub(super) temperature: i32,
+    pub(super) flags: u32,
+    pub(super) dither_mode: i32,
+    pub(super) quant_bit: i32,
+    pub(super) alternate_buffer: AlternateBuffer,
+    pub(super) hist_bw_waveform_mode: u32,
+    pub(super) hist_gray_waveform_mode: u32,
+}
+
 // Kindle EPDC ioctl and constants.
 // The ioctl number was confirmed by stracing `eips` on a real device.
 pub(super) const MXCFB_SEND_UPDATE: libc::c_ulong = 0x4048_462e;

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -5,9 +5,9 @@ use std::os::fd::AsRawFd;
 
 use ffi::{
     AlternateBuffer, FBIOGET_FSCREENINFO, FBIOGET_VSCREENINFO, FbFixScreeninfo, FbVarScreeninfo,
-    MXCFB_SEND_UPDATE, MXCFB_WAIT_FOR_UPDATE_COMPLETE, TEMP_USE_AMBIENT, UPDATE_MODE_FULL,
-    UPDATE_MODE_PARTIAL, UpdateMarkerData, UpdateRect, UpdateRequest, WAVEFORM_MODE_AUTO,
-    WAVEFORM_MODE_GC16,
+    MXCFB_SEND_UPDATE, MXCFB_SEND_UPDATE_V2, MXCFB_WAIT_FOR_UPDATE_COMPLETE, TEMP_USE_AMBIENT,
+    UPDATE_MODE_FULL, UPDATE_MODE_PARTIAL, UpdateMarkerData, UpdateRect, UpdateRequest,
+    WAVEFORM_MODE_AUTO, WAVEFORM_MODE_GC16,
 };
 
 /// Memory-mapped handle to the Kindle's e-ink framebuffer.
@@ -146,13 +146,21 @@ impl Framebuffer {
             },
         };
 
+        // Try original update command first, try modern address if that fails.
         unsafe {
-            libc::ioctl(
+            if libc::ioctl(
                 self.file.as_raw_fd(),
                 MXCFB_SEND_UPDATE as _,
                 &update as *const _,
-            );
-        }
+            ) == -1
+            {
+                libc::ioctl(
+                    self.file.as_raw_fd(),
+                    MXCFB_SEND_UPDATE_V2 as _,
+                    &update as *const _,
+                );
+            }
+        };
     }
 
     /// Full-screen GC16 refresh

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -7,7 +7,7 @@ use ffi::{
     AlternateBuffer, FBIOGET_FSCREENINFO, FBIOGET_VSCREENINFO, FbFixScreeninfo, FbVarScreeninfo,
     MXCFB_SEND_UPDATE, MXCFB_SEND_UPDATE_V2, MXCFB_WAIT_FOR_UPDATE_COMPLETE, TEMP_USE_AMBIENT,
     UPDATE_MODE_FULL, UPDATE_MODE_PARTIAL, UpdateMarkerData, UpdateRect, UpdateRequest,
-    WAVEFORM_MODE_AUTO, WAVEFORM_MODE_GC16,
+    WAVEFORM_MODE_AUTO, WAVEFORM_MODE_GC16, UpdateRequestRex
 };
 
 /// Memory-mapped handle to the Kindle's e-ink framebuffer.
@@ -154,13 +154,36 @@ impl Framebuffer {
                 &update as *const _,
             ) == -1
             {
+                let update = UpdateRequestRex {
+                    update_region: region,
+                    waveform_mode: waveform,
+                    update_mode: mode,
+                    update_marker: 1,
+                    temperature: TEMP_USE_AMBIENT,
+                    flags: 0,
+                    dither_mode: 0,
+                    quant_bit: 0,
+                    alternate_buffer: AlternateBuffer {
+                        physical_address: 0,
+                        width: 0,
+                        height: 0,
+                        update_region: UpdateRect {
+                            top: 0,
+                            left: 0,
+                            width: 0,
+                            height: 0,
+                        },
+                    },
+                    hist_bw_waveform_mode: 0,
+                    hist_gray_waveform_mode: 0,
+                };
                 libc::ioctl(
                     self.file.as_raw_fd(),
                     MXCFB_SEND_UPDATE_V2 as _,
                     &update as *const _,
                 );
             }
-        };
+        }
     }
 
     /// Full-screen GC16 refresh


### PR DESCRIPTION
I found the original address doesn't work on my 10th gen paperwhite, and some stracing surfaced this one, which I've confirmed works!

Demo: https://floofy.tech/@arch/116686027466675867

There may be a better way of doing the fallback or naming the variable, but this at least get the conversation going :)