### PR TITLE
Add Zelda (KOA2/KOA3 — Oasis 2/3) EPDC update variant

### DIFF
--- a/src/framebuffer/ffi.rs
+++ b/src/framebuffer/ffi.rs
@@ -148,6 +148,26 @@ pub(super) struct UpdateRequestMtk {
     pub(super) ts_epdc: u32,
 }
 
+// Zelda-based Kindles (KOA2, KOA3 — Oasis 2/3). Same as MTK but without
+// swipe_data, making it 88 bytes instead of 96.
+#[repr(C)]
+#[derive(Default)]
+pub(super) struct UpdateRequestZelda {
+    pub(super) update_region: UpdateRect,
+    pub(super) waveform_mode: u32,
+    pub(super) update_mode: u32,
+    pub(super) update_marker: u32,
+    pub(super) temperature: i32,
+    pub(super) flags: u32,
+    pub(super) dither_mode: i32,
+    pub(super) quant_bit: i32,
+    pub(super) alternate_buffer: AlternateBuffer,
+    pub(super) hist_bw_waveform_mode: u32,
+    pub(super) hist_gray_waveform_mode: u32,
+    pub(super) ts_pxp: u32,
+    pub(super) ts_epdc: u32,
+}
+
 // Kindle EPDC ioctl and constants.
 // The ioctl number was confirmed by stracing `eips` on a real device.
 pub(super) const MXCFB_SEND_UPDATE: libc::c_ulong = 0x4048_462e;
@@ -155,11 +175,15 @@ pub(super) const MXCFB_SEND_UPDATE: libc::c_ulong = 0x4048_462e;
 // ioctl number for Kindle Paperwhite 10th gen, from strace.
 pub(super) const MXCFB_SEND_UPDATE_REX: libc::c_ulong = 0x4050_462e;
 
+// _IOW('F', 0x2E, struct mxcfb_update_data_zelda) 88-byte struct on KOA2/KOA3.
+pub(super) const MXCFB_SEND_UPDATE_ZELDA: libc::c_ulong = 0x4058_462e;
+
 // _IOW('F', 0x2E, struct mxcfb_update_data_mtk) 96-byte struct on MTK devices.
 pub(super) const MXCFB_SEND_UPDATE_MTK: libc::c_ulong = 0x4060_462e;
 
 const _: () = assert!(std::mem::size_of::<UpdateRequest>() == 72);
 const _: () = assert!(std::mem::size_of::<UpdateRequestRex>() == 80);
+const _: () = assert!(std::mem::size_of::<UpdateRequestZelda>() == 88);
 const _: () = assert!(std::mem::size_of::<UpdateRequestMtk>() == 96);
 
 // Blocks until the EPDC has finished applying the update with a given marker.

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -6,9 +6,10 @@ use std::os::fd::AsRawFd;
 
 use ffi::{
     FBIOGET_FSCREENINFO, FBIOGET_VSCREENINFO, FbFixScreeninfo, FbVarScreeninfo, MXCFB_SEND_UPDATE,
-    MXCFB_SEND_UPDATE_MTK, MXCFB_SEND_UPDATE_REX, MXCFB_WAIT_FOR_UPDATE_COMPLETE, TEMP_USE_AMBIENT,
-    UPDATE_MODE_FULL, UPDATE_MODE_PARTIAL, UpdateMarkerData, UpdateRect, UpdateRequest,
-    UpdateRequestMtk, UpdateRequestRex, WAVEFORM_MODE_AUTO, WAVEFORM_MODE_GC16,
+    MXCFB_SEND_UPDATE_MTK, MXCFB_SEND_UPDATE_REX, MXCFB_SEND_UPDATE_ZELDA,
+    MXCFB_WAIT_FOR_UPDATE_COMPLETE, TEMP_USE_AMBIENT, UPDATE_MODE_FULL, UPDATE_MODE_PARTIAL,
+    UpdateMarkerData, UpdateRect, UpdateRequest, UpdateRequestMtk, UpdateRequestRex,
+    UpdateRequestZelda, WAVEFORM_MODE_AUTO, WAVEFORM_MODE_GC16,
 };
 
 /// Which MXCFB update ioctl this kernel accepts, varies with the Kindle model
@@ -20,6 +21,8 @@ enum UpdateVariant {
     Legacy,
     /// `MXCFB_SEND_UPDATE_REX` — 80-byte struct, Paperwhite 10th gen and newer.
     Rex,
+    /// `MXCFB_SEND_UPDATE_ZELDA` — 88-byte struct, KOA2/KOA3 (Oasis 2/3).
+    Zelda,
     /// `MXCFB_SEND_UPDATE_MTK` — 96-byte struct, MediaTek devices (Basic 2022,
     /// Paperwhite 5, Scribe).
     Mtk,
@@ -30,7 +33,7 @@ enum UpdateVariant {
 
 impl UpdateVariant {
     /// Probed oldest ABI first.
-    const PROBE_ORDER: [UpdateVariant; 3] = [Self::Legacy, Self::Rex, Self::Mtk];
+    const PROBE_ORDER: [UpdateVariant; 4] = [Self::Legacy, Self::Rex, Self::Zelda, Self::Mtk];
 }
 
 /// Memory-mapped handle to the Kindle's e-ink framebuffer.
@@ -199,6 +202,7 @@ impl Framebuffer {
         match variant {
             UpdateVariant::Legacy => self.send_update_legacy(region, waveform, mode),
             UpdateVariant::Rex => self.send_update_rex(region, waveform, mode),
+            UpdateVariant::Zelda => self.send_update_zelda(region, waveform, mode),
             UpdateVariant::Mtk => self.send_update_mtk(region, waveform, mode),
             UpdateVariant::Unsupported => false,
         }
@@ -251,6 +255,20 @@ impl Framebuffer {
             ..Default::default()
         };
         self.send_update_ioctl(MXCFB_SEND_UPDATE_MTK, &update)
+    }
+
+    /// Issue `MXCFB_SEND_UPDATE_ZELDA` (88-byte struct, KOA2/KOA3 — Oasis 2/3).
+    /// Returns whether the ioctl succeeded.
+    fn send_update_zelda(&self, region: UpdateRect, waveform: u32, mode: u32) -> bool {
+        let update = UpdateRequestZelda {
+            update_region: region,
+            waveform_mode: waveform,
+            update_mode: mode,
+            update_marker: 1,
+            temperature: TEMP_USE_AMBIENT,
+            ..Default::default()
+        };
+        self.send_update_ioctl(MXCFB_SEND_UPDATE_ZELDA, &update)
     }
 
     /// Full-screen GC16 refresh


### PR DESCRIPTION
## Problem

The Kindle Oasis 2 (KOA2) and Oasis 3 (KOA3) use the **Zelda** EPDC update struct (`mxcfb_update_data_zelda`), which is **88 bytes** — distinct from all three existing variants:

| Variant | Struct | Size | Devices |
|---------|--------|------|---------|
| Legacy | `mxcfb_update_data` | 72B | Older devices |
| Rex | `mxcfb_update_data_rex` | 80B | PW4, KT4 |
| **Zelda (new)** | `mxcfb_update_data_zelda` | **88B** | **KOA2, KOA3 (Oasis 2/3)** |
| MTK | `mxcfb_update_data_mtk` | 96B | Basic 2022, PW5, Scribe |

Without Zelda support, the ioctl probe fails on all three existing variants and the e-ink panel never refreshes. The framebuffer memory is written correctly, but the screen stays blank — the app appears to hang, and only flashes briefly when the framework restore triggers a refresh on exit.

## Fix

- Added `UpdateRequestZelda` struct (88 bytes) matching the kernel ABI from Amazon's open-source `mxcfb.h` headers
- Added `MXCFB_SEND_UPDATE_ZELDA` ioctl constant (`0x4058462e` = `_IOW('F', 0x2E, struct mxcfb_update_data_zelda)`)
- Added `UpdateVariant::Zelda` to the probe order (between Rex and MTK)
- Added `send_update_zelda()` method

The Zelda struct matches the Rex layout but adds `ts_pxp` and `ts_epdc` debugging timestamp fields (and drops the MTK-specific `swipe_data`).

## Testing

Tested on a **Kindle Oasis 3 (10th gen)** — UI now renders correctly to the e-ink panel. Touch input and screen refresh both work as expected.

## References

- Struct definitions from [FBInk's `eink/mxcfb-kindle.h`](https://github.com/NiLuJe/FBInk/blob/master/eink/mxcfb-kindle.h) (the definitive Kindle e-ink library)
- Amazon's open-source kernel headers confirm the Zelda ABI for KOA2/KOA3

Generated with [Devin](https://devin.ai)